### PR TITLE
Update exynos990-c2slte_eur_open_21.dts

### DIFF
--- a/arch/arm64/boot/dts/samsung/exynos990-c2slte_eur_open_21.dts
+++ b/arch/arm64/boot/dts/samsung/exynos990-c2slte_eur_open_21.dts
@@ -9,7 +9,7 @@
 	fragment@0 {
 		target = <0xffffffff>;
 
-		__overlay__ {i
+		__overlay__ {
 
 			m-pmic-irq {
 				samsung,pins = "gpa0-1";


### PR DESCRIPTION
syntax error, removed "i" to fix it